### PR TITLE
Add a kwarg to override relationships rendered in jsonapi errors

### DIFF
--- a/lib/jsonapi_errorable/validatable.rb
+++ b/lib/jsonapi_errorable/validatable.rb
@@ -1,13 +1,17 @@
 module JsonapiErrorable
   module Validatable
-    # @param relationships: nil [Hash] list of relationships to be serialized as errors
+    # @param relationships: nil [ Hash or FalseClass ] list of relationships whose errors should be serialized
+    #   Defaults to the deserialized data.relationships of Json:api Payload
     # @param record [ ActiveModel ] Object that implements ActiveModel
     def render_errors_for(record, relationships: nil)
-      validation = Serializers::Validation.new(
-        record,
-        relationships || deserialized_params.relationships
-      )
-      
+      relationships =
+        if relationships == false
+          {}
+        else
+          relationships || deserialized_params.relationships
+        end
+
+      validation = Serializers::Validation.new(record, relationships)
 
       render \
         json: { errors: validation.errors },

--- a/lib/jsonapi_errorable/validatable.rb
+++ b/lib/jsonapi_errorable/validatable.rb
@@ -1,8 +1,13 @@
 module JsonapiErrorable
   module Validatable
-    def render_errors_for(record)
-      validation = Serializers::Validation.new \
-        record, deserialized_params.relationships
+    # @param relationships: nil [Hash] list of relationships to be serialized as errors
+    # @param record [ ActiveModel ] Object that implements ActiveModel
+    def render_errors_for(record, relationships: nil)
+      validation = Serializers::Validation.new(
+        record,
+        relationships || deserialized_params.relationships
+      )
+      
 
       render \
         json: { errors: validation.errors },

--- a/lib/jsonapi_errorable/validatable.rb
+++ b/lib/jsonapi_errorable/validatable.rb
@@ -3,13 +3,8 @@ module JsonapiErrorable
     # @param relationships: nil [ Hash or FalseClass ] list of relationships whose errors should be serialized
     #   Defaults to the deserialized data.relationships of Json:api Payload
     # @param record [ ActiveModel ] Object that implements ActiveModel
-    def render_errors_for(record, relationships: nil)
-      relationships =
-        if relationships == false
-          {}
-        else
-          relationships || deserialized_params.relationships
-        end
+    def render_errors_for(record, relationships: {})
+      relationships || deserialized_params.relationships
 
       validation = Serializers::Validation.new(record, relationships)
 


### PR DESCRIPTION
This especially allows to render jsonapi errors without a jsonapi payload (such as GET requests) by passing `relationships: {}`

Features
- [x] Pass `relationships: false` to send empty second argument
- [x] `relationships:` Argument is optional
- [x] Non breaking changes (default remains to send controller deserialized relationships)