### PR TITLE
Respect ActiveModel 'base' validations pattern

### DIFF
--- a/lib/jsonapi_errorable/serializers/validation.rb
+++ b/lib/jsonapi_errorable/serializers/validation.rb
@@ -16,11 +16,18 @@ module JsonapiErrorable
           messages.map do |message|
             meta = { attribute: attribute, message: message }.merge(@relationship_message)
             meta = { relationship: meta } if @relationship_message.present?
+
+            detail = "#{attribute.capitalize} #{message}"
+
+            if attribute.to_s.downcase == 'base'
+              detail = message
+            end
+
             {
               code:   'unprocessable_entity',
               status: '422',
               title: 'Validation Error',
-              detail: "#{attribute.capitalize} #{message}",
+              detail: detail,
               source: { pointer: pointer_for(object, attribute) },
               meta:   meta
             }

--- a/spec/serializers/serializable_validation_spec.rb
+++ b/spec/serializers/serializable_validation_spec.rb
@@ -43,6 +43,32 @@ RSpec.describe JsonapiErrorable::Serializers::Validation do
           ]
         )
       end
+
+      context 'when the error attribute is "base"' do
+        let(:errors_hash) { { base: ["Model is invalid"] } }
+
+        before do
+          allow(object).to receive(:respond_to?).with(:base) { true }
+        end
+
+        it 'should not render the attribute in the message detail' do
+          expect(subject).to eq(
+            [
+              {
+                code:  'unprocessable_entity',
+                status: '422',
+                title: "Validation Error",
+                detail: "Model is invalid",
+                source: { pointer: '/data/attributes/base' },
+                meta: {
+                  attribute: :base,
+                  message: "Model is invalid"
+                }
+              }
+            ]
+          )
+        end
+      end
     end
 
     context 'when the error is on a relationship' do


### PR DESCRIPTION
It is a common pattern for activerecord and activemodel models to
indicate errors that are not on a given field but rather on the entire
model by adding an error to the "base" attribute.  In this case the
message tends to be a complete sentence about the model state, rather
than a clause appended to the attribute name ("can't be blank").  In
this case, we don't want to append "Base" to the beginning of the error
message.