### PR TITLE
Allow error handler to have dynamic status

### DIFF
--- a/lib/jsonapi_errorable/exception_handler.rb
+++ b/lib/jsonapi_errorable/exception_handler.rb
@@ -44,7 +44,7 @@ module JsonapiErrorable
         if show_raw_error
           meta_payload[:__raw_error__] = {
             message: error.message,
-            backtrace: error.backtrace.join("\n")
+            backtrace: error.backtrace
           }
         end
       end


### PR DESCRIPTION
This allows a pattern whereby there is a single error handler
registration for some base class of errors, and each error can deal with
setting its own HTTP status code.