### PR TITLE
Add error code under meta in serialization

### DIFF
--- a/lib/jsonapi_errorable/serializers/validation.rb
+++ b/lib/jsonapi_errorable/serializers/validation.rb
@@ -15,7 +15,7 @@ module JsonapiErrorable
         all_errors = object.errors.details.map do |attribute, error_symbols|
           error_symbols.map do |error_hash|
             error_symbol = error_hash[:error]
-            message = generate_message(attribute, error_symbol)
+            message = object.errors.generate_message(attribute, error_symbol)
 
             meta = { attribute: attribute, message: message, code: error_symbol }
             meta = { relationship: meta } if @relationship_message.present?

--- a/lib/jsonapi_errorable/serializers/validation.rb
+++ b/lib/jsonapi_errorable/serializers/validation.rb
@@ -17,11 +17,8 @@ module JsonapiErrorable
             error_symbol = error_hash[:error]
             message = generate_message(attribute, error_symbol)
 
-            if @relationship_message.present?
-              meta = { relationship: meta }
-            else
-              meta = { attribute: attribute, message: message, code: error_symbol }
-            end
+            meta = { attribute: attribute, message: message, code: error_symbol }
+            meta = { relationship: meta } if @relationship_message.present?
 
             detail = object.errors.full_message(attribute, message)
             detail = message if attribute.to_s.downcase == 'base'

--- a/lib/jsonapi_errorable/serializers/validation.rb
+++ b/lib/jsonapi_errorable/serializers/validation.rb
@@ -12,10 +12,16 @@ module JsonapiErrorable
       def errors
         return [] unless object.respond_to?(:errors)
 
-        all_errors = object.errors.to_hash.map do |attribute, messages|
-          messages.map do |message|
-            meta = { attribute: attribute, message: message }.merge(@relationship_message)
-            meta = { relationship: meta } if @relationship_message.present?
+        all_errors = object.errors.details.map do |attribute, error_symbols|
+          error_symbols.map do |error_hash|
+            error_symbol = error_hash[:error]
+            message = generate_message(attribute, error_symbol)
+
+            if @relationship_message.present?
+              meta = { relationship: meta }
+            else
+              meta = { attribute: attribute, message: message, code: error_symbol }
+            end
 
             detail = object.errors.full_message(attribute, message)
             detail = message if attribute.to_s.downcase == 'base'


### PR DESCRIPTION
Serialize ActiveModel "error symbol"s under the `meta` key in the jsonapi payload as suggested in #11 