### PR TITLE
Add show_raw_error option

### DIFF
--- a/gemfiles/rails_4.gemfile.lock
+++ b/gemfiles/rails_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    jsonapi_errorable (0.7.0)
+    jsonapi_errorable (0.8.0)
       jsonapi-serializable (~> 0.1)
 
 GEM

--- a/gemfiles/rails_5.gemfile.lock
+++ b/gemfiles/rails_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    jsonapi_errorable (0.7.0)
+    jsonapi_errorable (0.8.0)
       jsonapi-serializable (~> 0.1)
 
 GEM

--- a/lib/jsonapi_errorable.rb
+++ b/lib/jsonapi_errorable.rb
@@ -41,10 +41,11 @@ module JsonapiErrorable
     @logger = logger
   end
 
-  def handle_exception(e)
+  def handle_exception(e, show_raw_error: false)
     raise e if JsonapiErrorable.disabled?
 
     exception_klass = self.class._errorable_registry[e.class] || default_exception_handler.new
+    exception_klass.show_raw_error = show_raw_error
     exception_klass.log(e)
     json   = exception_klass.error_payload(e)
     status = exception_klass.status_code(e)

--- a/lib/jsonapi_errorable/exception_handler.rb
+++ b/lib/jsonapi_errorable/exception_handler.rb
@@ -1,5 +1,7 @@
 module JsonapiErrorable
   class ExceptionHandler
+    attr_accessor :show_raw_error
+
     def initialize(options = {})
       @status  = options[:status]
       @title   = options[:title]
@@ -34,8 +36,18 @@ module JsonapiErrorable
     end
 
     def meta(error)
-      return {} unless @meta.respond_to?(:call)
-      @meta.call(error)
+      {}.tap do |meta_payload|
+        if @meta.respond_to?(:call)
+          meta_payload.merge!(@meta.call(error))
+        end
+
+        if show_raw_error
+          meta_payload[:__raw_error__] = {
+            message: error.message,
+            backtrace: error.backtrace.join("\n")
+          }
+        end
+      end
     end
 
     def error_payload(error)


### PR DESCRIPTION
This option enables conditional rendering of the actual error
message and stacktrace. Given

```ruby
rescue_from Exception do |e|
  handle_exception(e, show_raw_error: current_user.internal?)
end
```

The `meta` payload will contain a `__raw_error__` key containing the
message and backtrace.