### PR TITLE
removed unnecessary method call

### DIFF
--- a/lib/jsonapi_errorable/serializers/validation.rb
+++ b/lib/jsonapi_errorable/serializers/validation.rb
@@ -123,7 +123,6 @@ module JsonapiErrorable
             end
 
             yield name, relationship_object, related_payload
-            relationship_errors(related_payload[:relationships])
           end
         end
       end


### PR DESCRIPTION
You shouldn't call method "relationship_errors" with relationships of relationships. Parent object tries to find children's relationships in itself that it doesn't have.